### PR TITLE
GHC 9.0 compatibility

### DIFF
--- a/Control/Monad/Trans/Tardis.hs
+++ b/Control/Monad/Trans/Tardis.hs
@@ -144,7 +144,7 @@ instance MonadFix m => MonadFix (TardisT bw fw m) where
     return (x, s')
 
 instance MFunctor (TardisT bw fw) where
-  hoist = mapTardisT
+  hoist f = mapTardisT f
 
 -- Basics
 -------------------------------------------------


### PR DESCRIPTION
Eta expansion is needed in one location to account for simplified subsumption in GHC 9.0.