### PR TITLE
fix: support for ghc 9.6 MonadFix constraint in MonadTrans

### DIFF
--- a/src/Control/Monad/Trans/Tardis.hs
+++ b/src/Control/Monad/Trans/Tardis.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecursiveDo                     #-}
+{-# LANGUAGE QuantifiedConstraints           #-}
 
 -- | The data definition of a "TardisT"
 -- as well as its primitive operations,
@@ -133,7 +134,7 @@ instance MonadFix m => Applicative (TardisT bw fw m) where
   (<*>) = ap
 
 
-instance MonadTrans (TardisT bw fw) where
+instance (forall m. MonadFix m) => MonadTrans (TardisT bw fw) where
   lift m = TardisT $ \s -> do
     x <- m
     return (x, s)


### PR DESCRIPTION
`lift` requires `Monad m` in `TardisT bw fw m a`.

However, `m` does not appear in the instance declaration (because `MonadTrans (TardisT bw fw)`.

Actually, the fix is a bit unclear to me, I just added `forall m. MonadFix m` and it fixs the problem, but adding `forall duck. MonadFix duck` also fixs the problem.