### PR TITLE
fix: support for ghc 9.6 - Remove MonadTrans

### DIFF
--- a/src/Control/Monad/Trans/Tardis.hs
+++ b/src/Control/Monad/Trans/Tardis.hs
@@ -122,7 +122,6 @@ noState = (undefined, undefined)
 -------------------------------------------------
 
 instance Monad (TardisT bw fw m) where
-  return x = TardisT $ \s -> pure (x, s)
   m >>= f  = TardisT $ \ ~(bw, fw) -> do
     rec (x,  ~(bw'', fw' )) <- runTardisT m (bw', fw)
         (x', ~(bw' , fw'')) <- runTardisT (f x) (bw, fw')
@@ -132,7 +131,7 @@ instance Functor (TardisT bw fw m) where
   fmap = liftM
 
 instance Applicative (TardisT bw fw m) where
-  pure = return
+  pure x = TardisT $ \s -> pure (x, s)
   (<*>) = ap
 
 instance MonadTrans (TardisT bw fw) where


### PR DESCRIPTION
`Monad` for `TardisT` requires that the underlying `Monad` be an instance of `MonadFix`, which is not general enough for `TardisT` to be an instance of `MonadTrans` since `MonadTrans` got a `forall m. Monad m => Monad (t m)` constraint. (where `t ~ TardisT a b` in our context) in transformers `0.6`.

This commit removes the `MonadTrans` instance and instead provides a `liftTardis` function which will hopefully cover most use case previously covered by `lift`.

See https://github.com/DanBurton/tardis/issues/15 for discussion.