### PR TITLE
Support MicroHs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist
 /dist-newstyle
 .stack-work
+dist-mcabal

--- a/src/Control/Monad/Tardis.hs
+++ b/src/Control/Monad/Tardis.hs
@@ -61,14 +61,14 @@ import Control.Monad.Trans.Tardis
     while setting the backwards-traveling state will affect the /past/.
     Take a look at how Monadic bind is implemented for 'TardisT':
 
-> m >>= f  = TardisT $ \ ~(bw, fw) -> do
->   rec (x,  ~(bw'', fw' )) <- runTardisT m (bw', fw)
->       (x', ~(bw' , fw'')) <- runTardisT (f x) (bw, fw')
+> m >>= f  = TardisT $ \ ~(bw, fw) -> mdo
+>   (x,  ~(bw'', fw' )) <- runTardisT m (bw', fw)
+>   (x', ~(bw' , fw'')) <- runTardisT (f x) (bw, fw')
 >   return (x', (bw'', fw''))
 
     Like the Reverse State monad transformer, TardisT's Monad instance
     requires that the monad it transforms is an instance of MonadFix,
-    as is evidenced by the use of @rec@.
+    as is evidenced by the use of @mdo@.
     Notice how the forwards-traveling state travels /normally/:
     first it is fed to @m@, producing @fw'@, and then it is fed to @f x@,
     producing @fw''@. The backwards-traveling state travels in the opposite

--- a/src/Control/Monad/Tardis/Class.hs
+++ b/src/Control/Monad/Tardis/Class.hs
@@ -66,13 +66,12 @@ class (Applicative m, MonadFix m) => MonadTardis bw fw m | m -> bw, m -> fw wher
 
   -- | A Tardis is merely a pure state transformation.
   tardis :: ((bw, fw) -> (a, (bw, fw))) -> m a
-  tardis f = do
-    rec
-      let (a, (future', past')) = f (future, past)
-      sendPast future'
-      past <- getPast
-      future <- getFuture
-      sendFuture past'
+  tardis f = mdo
+    let (a, (future', past')) = f (future, past)
+    sendPast future'
+    past <- getPast
+    future <- getFuture
+    sendFuture past'
     return a
 
 -- | Modify the forwards-traveling state
@@ -83,10 +82,9 @@ modifyForwards f = getPast >>= sendFuture . f
 -- | Modify the backwards-traveling state
 -- as it passes through from future to past.
 modifyBackwards :: MonadTardis bw fw m => (bw -> bw) -> m ()
-modifyBackwards f = do
-  rec
-    sendPast (f x)
-    x <- getFuture
+modifyBackwards f = mdo
+  sendPast (f x)
+  x <- getFuture
   return ()
 
 -- | Retrieve a specific view of the forwards-traveling state.

--- a/src/Control/Monad/Trans/Tardis.hs
+++ b/src/Control/Monad/Trans/Tardis.hs
@@ -126,9 +126,9 @@ noState = (undefined, undefined)
 
 instance MonadFix m => Monad (TardisT bw fw m) where
   return x = tardis $ \s -> (x, s)
-  m >>= f  = TardisT $ \ ~(bw, fw) -> do
-    rec (x,  ~(bw'', fw' )) <- runTardisT m (bw', fw)
-        (x', ~(bw' , fw'')) <- runTardisT (f x) (bw, fw')
+  m >>= f  = TardisT $ \ ~(bw, fw) -> mdo
+    (x,  ~(bw'', fw' )) <- runTardisT m (bw', fw)
+    (x', ~(bw' , fw'')) <- runTardisT (f x) (bw, fw')
     return (x', (bw'', fw''))
 
 instance MonadFix m => Functor (TardisT bw fw m) where
@@ -139,8 +139,8 @@ instance MonadFix m => Applicative (TardisT bw fw m) where
   (<*>) = ap
 
 instance MonadFix m => MonadFix (TardisT bw fw m) where
-  mfix f = TardisT $ \s -> do
-    rec (x, s') <- runTardisT (f x) s
+  mfix f = TardisT $ \s -> mdo
+    (x, s') <- runTardisT (f x) s
     return (x, s')
 
 instance MFunctor (TardisT bw fw) where
@@ -194,10 +194,9 @@ modifyForwards f = getPast >>= sendFuture . f
 -- | Modify the backwards-traveling state
 -- as it passes through from future to past.
 modifyBackwards :: MonadFix m => (bw -> bw) -> TardisT bw fw m ()
-modifyBackwards f = do
-  rec
-    sendPast (f x)
-    x <- getFuture
+modifyBackwards f = mdo
+  sendPast (f x)
+  x <- getFuture
   return ()
 
 

--- a/test/Example.hs
+++ b/test/Example.hs
@@ -38,17 +38,16 @@ toScores game = flip evalTardis initState $ go (frames game) where
     PreviousScores scores <- getPast
     let score = head scores
     return $ (finalFrameScore + score) : scores
-  go (f : fs) = do
-    rec
-      sendPast $ NextThrows throws'
-      PreviousScores scores <- getPast
-      let score = head scores
-      sendFuture $ PreviousScores (score' : scores)
-      NextThrows ~(nextThrow1, nextThrow2) <- getFuture
-      let (score', throws') = case f of
-            Strike    -> (score + 10 + nextThrow1 + nextThrow2, (10, nextThrow1))
-            Spare n   -> (score + 10 + nextThrow1,              (n, 10 - n))
-            Frame n m -> (score + n + m,                        (n, m))
+  go (f : fs) = mdo
+    sendPast $ NextThrows throws'
+    PreviousScores scores <- getPast
+    let score = head scores
+    sendFuture $ PreviousScores (score' : scores)
+    NextThrows ~(nextThrow1, nextThrow2) <- getFuture
+    let (score', throws') = case f of
+          Strike    -> (score + 10 + nextThrow1 + nextThrow2, (10, nextThrow1))
+          Spare n   -> (score + 10 + nextThrow1,              (n, 10 - n))
+          Frame n m -> (score + n + m,                        (n, m))
     go fs
 
   finalFrameScore = case lastFrame game of


### PR DESCRIPTION
[MicroHs](https://github.com/augustss/MicroHs) doesn't support indented `rec` blocks (since `rec` is also allowed as variable name), so use `mdo` instead. I also checked that the example test works.